### PR TITLE
Run: load images metadata (env, labels, …)

### DIFF
--- a/Dockerfile.docker
+++ b/Dockerfile.docker
@@ -8,5 +8,6 @@ RUN --mount=target=. --mount=target=/root/.cache,type=cache --mount=target=/go/p
 
 FROM scratch
 COPY --from=build-buildkit /out/ /
-LABEL moby.buildkit.frontend.network.none="true"
+LABEL moby.buildkit.frontend.network.none="false"
+LABEL moby.buildkit.frontend.caps="moby.buildkit.frontend.inputs,moby.buildkit.frontend.subrequests,moby.buildkit.frontend.contexts"
 ENTRYPOINT ["/buildkit-tekton", "frontend"]

--- a/cmd/buildkit-tekton/main.go
+++ b/cmd/buildkit-tekton/main.go
@@ -42,7 +42,7 @@ func main() {
 
 func printGraph(filename string, out io.Writer) error {
 	b, _ := ioutil.ReadFile(filename)
-	st, err := tekton.TektonToLLB(string(b))
+	st, err := tekton.TektonToLLB(nil)(context.Background(), string(b))
 	if err != nil {
 		return errors.Wrap(err, "to llb")
 	}

--- a/examples/1-go-pipelinerun/run.yaml
+++ b/examples/1-go-pipelinerun/run.yaml
@@ -37,7 +37,7 @@ spec:
           - name: unit-test
             image: docker.io/library/golang:1.17
             command: ["/bin/bash", "-c"]
-            args: ["pwd; ls -la; echo $PATH; /usr/local/go/bin/go test ./..."]
+            args: ["pwd; ls -la; echo $PATH; go test ./..."]
             workingDir: /workspace/source
         workspaces:
           - name: source

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/vdemeester/buildkit-tekton
 go 1.17
 
 require (
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/moby/buildkit v0.9.3
+	github.com/opencontainers/image-spec v1.0.3-0.20211202222133-eacdcc10569b
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/tektoncd/pipeline v0.32.1
@@ -24,7 +26,6 @@ require (
 	github.com/containerd/ttrpc v1.1.0 // indirect
 	github.com/containerd/typeurl v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v20.10.8+incompatible // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
@@ -58,7 +59,6 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.3-0.20211202222133-eacdcc10569b // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -21,7 +21,7 @@ func Build(ctx context.Context, c client.Client) (*client.Result, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getting tekton task")
 	}
-	st, err := tekton.TektonToLLB(cfg)
+	st, err := tekton.TektonToLLB(c)(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
That way, we are running the image very closely to what a `docker run`
would (with the correct set of environment variable and entrypoint).

Fixes #21

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
