### PR TITLE
TaskRun: add `env` support

### DIFF
--- a/examples/0-taskrun-simple/run-with-script.yaml
+++ b/examples/0-taskrun-simple/run-with-script.yaml
@@ -18,9 +18,19 @@ spec:
           #!/usr/bin/env bash
           set -e -u -x
           date | tee /tekton/results/current-date-unix-timestamp-human
+      - name: print-something-from-env
+        image: bash:latest
+        env:
+          - name: FOO
+            value: BAR
+        script: |
+          echo ${FOO} | tee /tekton/results/foo
       - name: list-results
         image: bash:latest
         script: |
+          #!/usr/bin/env bash
+          set -e -u -x
           ls -l /tekton/results/
-          cat /tekton/results/current-date-unix-timestamp-human
-          cat /tekton/results/current-date-unix-timestamp
+          [[ -f /tekton/results/current-date-unix-timestamp-human ]]
+          [[ -f /tekton/results/current-date-unix-timestamp ]]
+          [[ $(cat /tekton/results/foo) == BAR ]]

--- a/pkg/tekton/taskrun.go
+++ b/pkg/tekton/taskrun.go
@@ -158,6 +158,13 @@ func taskSpecToPSteps(ctx context.Context, c client.Client, t v1beta1.TaskSpec, 
 				llb.With(llb.Dir(step.WorkingDir)),
 			)
 		}
+		if len(step.Env) > 0 {
+			for _, e := range step.Env {
+				runOptions = append(runOptions,
+					llb.AddEnv(e.Name, e.Value),
+				)
+			}
+		}
 		results := []mountOptionFn{
 			func(state llb.State) llb.RunOption {
 				return llb.AddMount("/tekton/results", state, llb.AsPersistentCacheDir(cacheDirName, llb.CacheMountShared))


### PR DESCRIPTION
Run the task's steps with the additional env set on it.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
