### PR TITLE
PipelineRun: Fix variable interpolation for Tasks

### DIFF
--- a/pkg/tekton/pipelinerun.go
+++ b/pkg/tekton/pipelinerun.go
@@ -42,15 +42,29 @@ func PipelineRunToLLB(ctx context.Context, c client.Client, pr *v1beta1.Pipeline
 	tasks := map[string][]llb.State{}
 	for _, t := range ps.Tasks {
 		logrus.Infof("pipelinetask: %s", t.Name)
+		logrus.Infof("pipelinetask: %+v", t)
 		if t.TaskSpec == nil {
 			return llb.State{}, errors.Errorf("%s: TaskRef not supported", t.Name)
 		}
+
+		logrus.Infof("pipelinetask.TaskSpec: %+v", t.TaskSpec)
+		ts, err := applyTaskRunSubstitution(ctx, &v1beta1.TaskRun{
+			Spec: v1beta1.TaskRunSpec{
+				Params:   t.Params,
+				TaskSpec: &t.TaskSpec.TaskSpec,
+			},
+		})
+		if err != nil {
+			return llb.State{}, errors.Wrapf(err, "variable interpolation failed for %s", t.Name)
+		}
+
+		logrus.Infof("pipelinetask.TaskSpec: %+v", ts)
 		taskWorkspaces := map[string]llb.MountOption{}
 		for _, w := range t.Workspaces {
 			taskWorkspaces["/workspace/"+w.Name] = pipelineWorkspaces[w.Workspace]
 		}
 		logrus.Infof("taskWorkspaces: %+v", taskWorkspaces)
-		steps, err := taskSpecToPSteps(ctx, c, t.TaskSpec.TaskSpec, t.Name, taskWorkspaces)
+		steps, err := taskSpecToPSteps(ctx, c, ts, t.Name, taskWorkspaces)
 		if err != nil {
 			return llb.State{}, errors.Wrap(err, "couldn't translate TaskSpec to llb")
 		}

--- a/pkg/tekton/taskrun.go
+++ b/pkg/tekton/taskrun.go
@@ -118,6 +118,7 @@ func taskSpecToPSteps(ctx context.Context, c client.Client, t v1beta1.TaskSpec, 
 	}
 	logrus.Infof("+taskWorkspaces: %+v", taskWorkspaces)
 	for i, step := range t.Steps {
+		logrus.Infof("steps.image: %s", step.Image)
 		ref, err := reference.ParseNormalizedNamed(step.Image)
 		if err != nil {
 			return steps, err
@@ -185,6 +186,7 @@ func pstepToState(c client.Client, steps []pstep, resultState llb.State, additio
 	stepStates := make([]llb.State, len(steps))
 	for i, step := range steps {
 		logrus.Infof("step-%d: %s", i, step.name)
+		logrus.Infof("step-%d: %s", i, step.image)
 		runOptions := step.runOptions
 		mounts := make([]llb.RunOption, len(step.results))
 		for i, r := range step.results {


### PR DESCRIPTION
Before that, we wouldn't apply substitution to the Pipeline's Task,
making it not working (for example in case of `$(params.image)` uses)

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
