### PR TITLE
Add support to pass option on build

### DIFF
--- a/hack/test-buildctl.sh
+++ b/hack/test-buildctl.sh
@@ -40,6 +40,7 @@ for f in "${td}"/examples/*; do
             buildctl build --frontend gateway.v0 --opt source=${buildimage} \
                      --local dockerfile=. --local context=. \
                      --opt filename=$(basename ${sf}) \
+                     --opt enable-tekton-oci-bundles=true \
                      --output type=image,name=${name}
         done
 	)

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -31,7 +31,10 @@ for f in "${td}"/examples/*; do
 			    echo "#syntax=${image}"
 			    cat "${sf}"
 		    ) | sponge "${sf}"
-		    "$DOCKER" build -t "${name}" -f "${sf}" .
+		    "$DOCKER" build \
+                      --build-arg=enable-tekton-oci-bundles=true \
+                      -t "${name}" \
+                      -f "${sf}" .
         done
 	)
 done

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	"github.com/moby/buildkit/frontend/gateway/client"
+	"github.com/sirupsen/logrus"
+	"github.com/tektoncd/pipeline/pkg/apis/config"
+)
+
+type Config struct {
+	Defaults     config.Defaults
+	FeatureFlags config.FeatureFlags
+}
+
+func Parse(opts client.BuildOpts) (*Config, error) {
+	logrus.Infof("opts: %+v", opts)
+	c := &Config{}
+
+	for name, value := range opts.Opts {
+		logrus.Infof("%s: %s", name, value)
+		// we use --build-arg to pass option through "docker build"
+		// so we need to strip it to get the "real" option
+		if strings.HasPrefix(name, "build-arg:") {
+			name = strings.TrimPrefix(name, "build-arg:")
+		}
+		// TODO: Support more options
+		switch name {
+		case "enable-api-fields":
+			c.FeatureFlags.EnableAPIFields = value
+		case "enable-tekton-oci-bundles":
+			b, err := strconv.ParseBool(value)
+			if err != nil {
+				return c, err
+			}
+			c.FeatureFlags.EnableTektonOCIBundles = b
+		}
+	}
+
+	return c, nil
+}
+
+func (c *Config) ToContext(ctx context.Context) context.Context {
+	return config.ToContext(ctx, &config.Config{
+		Defaults:     &c.Defaults,
+		FeatureFlags: &c.FeatureFlags,
+	})
+}

--- a/pkg/tekton/oci.go
+++ b/pkg/tekton/oci.go
@@ -6,7 +6,6 @@ import (
 	"github.com/moby/buildkit/client/llb"
 	"github.com/moby/buildkit/frontend/gateway/client"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8scheme "k8s.io/client-go/kubernetes/scheme"
@@ -67,7 +66,6 @@ func resolveBundle(ctx context.Context, c client.Client, bundle, name string) (r
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to resolve %s in oci bundle: %s", name, bundle)
 	}
-	logrus.Infof("dt: %s", string(dt))
 	decoder := k8scheme.Codecs.UniversalDeserializer()
 	obj, _, err := decoder.Decode(dt, nil, nil)
 	if err != nil {

--- a/pkg/tekton/taskrun.go
+++ b/pkg/tekton/taskrun.go
@@ -55,7 +55,6 @@ func TaskRunToLLB(ctx context.Context, c client.Client, tr *v1beta1.TaskRun) (ll
 	if err != nil {
 		return llb.State{}, errors.Wrap(err, "variable interpolation failed")
 	}
-	logrus.Infof("TaskSpec: %+v", spec)
 
 	// Execution
 	workspaces := map[string]llb.MountOption{}
@@ -118,7 +117,6 @@ func taskSpecToPSteps(ctx context.Context, c client.Client, t v1beta1.TaskSpec, 
 	for _, w := range t.Workspaces {
 		taskWorkspaces["/workspace/"+w.Name] = workspaces[w.Name]
 	}
-	logrus.Infof("+taskWorkspaces: %+v", taskWorkspaces)
 	mergedSteps, err := v1beta1.MergeStepsWithStepTemplate(t.StepTemplate, t.Steps)
 	if err != nil {
 		return steps, errors.Wrap(err, "couldn't merge steps with StepTemplate")
@@ -175,7 +173,6 @@ func taskSpecToPSteps(ctx context.Context, c client.Client, t v1beta1.TaskSpec, 
 		if step.SecurityContext != nil {
 			if step.SecurityContext.RunAsUser != nil {
 				user := fmt.Sprintf("%d", *step.SecurityContext.RunAsUser)
-				logrus.Infof("user: %s", user)
 				runOptions = append(runOptions,
 					llb.With(llb.User(user)),
 				)


### PR DESCRIPTION
Options can be passed using `--build-arg` with `docker build` and
`--opt` on `buildctl`. As of today, the only supported option is to
enable tekton oci bundle configuration, but we can think of other
options in the futures (override parameters, pass runtime options, …)

It also add the enable-tekton-oci-bundles options to true on our test
for now. Long term, we need a better set of tests suites.

This also clean some logs.

Signed-off-by: Vincent Demeester <vdemeest@redhat.com>
